### PR TITLE
feat(portal): retrieve agent info from card.

### DIFF
--- a/gravitee-apim-console-webui/src/portal/navigation-items/portal-navigation-items.component.spec.ts
+++ b/gravitee-apim-console-webui/src/portal/navigation-items/portal-navigation-items.component.spec.ts
@@ -3555,15 +3555,30 @@ describe('PortalNavigationItemsComponent', () => {
       const dialog = await rootLoader.getHarness(SectionEntityPickerDialogHarness);
       await dialog.clickSubmitButton();
 
+      expectAimA2aProxyGet(agents[1].id, 'catalog-agent-2');
+      expectAimA2aProxyGet(agents[0].id, 'catalog-agent-1');
+
       expectCreateNavigationItemsInBulk(
-        [agents[1], agents[0]].map(agent => ({
-          title: agent.name,
-          type: 'AGENT',
-          area: 'TOP_NAVBAR',
-          parentId: folder.id,
-          visibility: 'PUBLIC',
-          apiId: agent.id,
-        })),
+        [
+          {
+            title: agents[1].name,
+            type: 'AGENT',
+            area: 'TOP_NAVBAR',
+            parentId: folder.id,
+            visibility: 'PUBLIC',
+            apiId: agents[1].id,
+            agentId: 'catalog-agent-2',
+          },
+          {
+            title: agents[0].name,
+            type: 'AGENT',
+            area: 'TOP_NAVBAR',
+            parentId: folder.id,
+            visibility: 'PUBLIC',
+            apiId: agents[0].id,
+            agentId: 'catalog-agent-1',
+          },
+        ],
         fakePortalNavigationItemsResponse({ items: [createdAgents[1], createdAgents[0]] }),
       );
 
@@ -3571,6 +3586,47 @@ describe('PortalNavigationItemsComponent', () => {
       await expectGetPageContent(createdAgents[0].termsAndConditionsPageContentId, '## Agent Usage Terms');
 
       expect(routerSpy).toHaveBeenCalledWith(['.'], expect.objectContaining({ queryParams: { navId: createdAgents[0].id } }));
+    });
+
+    it('should omit agentId when the AIM A2A proxy lookup fails', async () => {
+      const createdAgent = fakePortalNavigationAgent({
+        id: 'nav-agent-1',
+        apiId: agents[0].id,
+        title: agents[0].name,
+        parentId: folder.id,
+      });
+
+      component.onNodeMenuAction({
+        action: 'create',
+        itemType: 'AGENT',
+        node: { id: folder.id, label: folder.title, type: folder.type, data: folder },
+      });
+      fixture.detectChanges();
+      await fixture.whenStable();
+
+      expectAgentSearchResponse(agents);
+      const checkboxes = await rootLoader.getAllHarnesses(MatCheckboxHarness.with({ selector: '[data-testid^="picker-checkbox-"]' }));
+      await checkboxes[0].check();
+      await (await rootLoader.getHarness(SectionEntityPickerDialogHarness)).clickSubmitButton();
+
+      expectAimA2aProxyGetError(agents[0].id);
+
+      expectCreateNavigationItemsInBulk(
+        [
+          {
+            title: agents[0].name,
+            type: 'AGENT',
+            area: 'TOP_NAVBAR',
+            parentId: folder.id,
+            visibility: 'PUBLIC',
+            apiId: agents[0].id,
+          },
+        ],
+        fakePortalNavigationItemsResponse({ items: [createdAgent] }),
+      );
+
+      await expectGetNavigationItems(fakePortalNavigationItemsResponse({ items: [folder, createdAgent] }));
+      await expectGetPageContent(createdAgent.termsAndConditionsPageContentId, '## Agent Usage Terms');
     });
 
     it('should refresh the tree and show an actionable error after a partial bulk conflict', async () => {
@@ -3588,6 +3644,8 @@ describe('PortalNavigationItemsComponent', () => {
       const checkboxes = await rootLoader.getAllHarnesses(MatCheckboxHarness.with({ selector: '[data-testid^="picker-checkbox-"]' }));
       await checkboxes[0].check();
       await (await rootLoader.getHarness(SectionEntityPickerDialogHarness)).clickSubmitButton();
+
+      expectAimA2aProxyGet(agents[0].id, 'catalog-agent-1');
 
       const request = httpTestingController.expectOne({
         method: 'POST',
@@ -3777,6 +3835,22 @@ describe('PortalNavigationItemsComponent', () => {
     expect(req.request.body).toEqual({ query: '', apiTypes: ['V4_A2A_PROXY'] });
     req.flush({ data: agents, pagination: { totalCount: agents.length } });
     fixture.detectChanges();
+  }
+
+  function expectAimA2aProxyGet(apiId: string, agentId: string | null) {
+    const req = httpTestingController.expectOne({
+      method: 'GET',
+      url: `https://url.test:3000/gamma/organizations/organization-id/environments/DEFAULT/modules/aim/a2a-proxies/${apiId}`,
+    });
+    req.flush({ agentId });
+  }
+
+  function expectAimA2aProxyGetError(apiId: string) {
+    const req = httpTestingController.expectOne({
+      method: 'GET',
+      url: `https://url.test:3000/gamma/organizations/organization-id/environments/DEFAULT/modules/aim/a2a-proxies/${apiId}`,
+    });
+    req.flush('Not found', { status: 404, statusText: 'Not Found' });
   }
 
   function expectLinkedApiSearchResponse(apiId: string, apiName = apiId) {

--- a/gravitee-apim-console-webui/src/portal/navigation-items/portal-navigation-items.component.ts
+++ b/gravitee-apim-console-webui/src/portal/navigation-items/portal-navigation-items.component.ts
@@ -36,7 +36,7 @@ import { MatMenuItem, MatMenuModule, MatMenuTrigger } from '@angular/material/me
 import { MatIconModule } from '@angular/material/icon';
 import { MatDialog } from '@angular/material/dialog';
 import { MatTooltipModule } from '@angular/material/tooltip';
-import { BehaviorSubject, EMPTY, Observable, of } from 'rxjs';
+import { BehaviorSubject, EMPTY, forkJoin, Observable, of } from 'rxjs';
 import { HttpErrorResponse } from '@angular/common/http';
 import { AsyncPipe, NgTemplateOutlet, TitleCasePipe } from '@angular/common';
 import { MatCardModule } from '@angular/material/card';
@@ -82,6 +82,7 @@ import {
   hasSelfOrAncestorOfType,
   indexPortalNavigationItemsById,
   NewPortalNavigationItem,
+  NewAgentPortalNavigationItem,
   PortalArea,
   PortalNavigationAgent,
   PortalNavigationApi,
@@ -103,6 +104,7 @@ import { PortalNavigationItemService } from '../../services-ngx/portal-navigatio
 import { PortalPageContentService } from '../../services-ngx/portal-page-content.service';
 import { ApiV2Service } from '../../services-ngx/api-v2.service';
 import { ApiProductV2Service } from '../../services-ngx/api-product-v2.service';
+import { AimA2aProxyService } from '../../services-ngx/aim-a2a-proxy.service';
 import { GioPermissionService } from '../../shared/components/gio-permission/gio-permission.service';
 import { HasUnsavedChanges } from '../../shared/guards/has-unsaved-changes.guard';
 import { confirmDiscardChanges, normalizeContent } from '../../shared/utils/content.util';
@@ -157,6 +159,7 @@ type AgentBulkCreateResult = {
 export class PortalNavigationItemsComponent implements HasUnsavedChanges {
   private destroyRef = inject(DestroyRef);
   private readonly apiProductService = inject(ApiProductV2Service);
+  private readonly aimA2aProxyService = inject(AimA2aProxyService);
 
   // UI State & Forms
   protected isReadOnly = !inject(GioPermissionService).hasAnyMatching(['environment-documentation-u']);
@@ -802,16 +805,8 @@ export class PortalNavigationItemsComponent implements HasUnsavedChanges {
       return of({ createdItemId: null });
     }
 
-    const items: NewPortalNavigationItem[] = agents.map(agent => ({
-      title: agent.name,
-      type: 'AGENT',
-      area: 'TOP_NAVBAR',
-      parentId,
-      visibility,
-      apiId: agent.id,
-    }));
-
-    return this.portalNavigationItemsService.createNavigationItemsInBulk(items).pipe(
+    return forkJoin(agents.map(agent => this.toAgentNavigationItem(parentId, agent, visibility))).pipe(
+      switchMap(items => this.portalNavigationItemsService.createNavigationItemsInBulk(items)),
       map(response => {
         const createdAgentItems = response.items?.filter((item): item is PortalNavigationAgent => item.type === 'AGENT');
         return {
@@ -824,6 +819,25 @@ export class PortalNavigationItemsComponent implements HasUnsavedChanges {
           errorMessage: this.getAgentCreateErrorMessage(error),
         });
       }),
+    );
+  }
+
+  private toAgentNavigationItem(
+    parentId: string,
+    agent: SelectedSectionEntity,
+    visibility: PortalVisibility,
+  ): Observable<NewAgentPortalNavigationItem> {
+    const item: NewAgentPortalNavigationItem = {
+      title: agent.name,
+      type: 'AGENT',
+      area: 'TOP_NAVBAR',
+      parentId,
+      visibility,
+      apiId: agent.id,
+    };
+    return this.aimA2aProxyService.getA2aProxy(agent.id).pipe(
+      map(detail => (detail.agentId ? { ...item, agentId: detail.agentId } : item)),
+      catchError(() => of(item)),
     );
   }
 

--- a/gravitee-apim-console-webui/src/services-ngx/aim-a2a-proxy.service.spec.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/aim-a2a-proxy.service.spec.ts
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { HttpTestingController } from '@angular/common/http/testing';
+import { TestBed } from '@angular/core/testing';
+
+import { AimA2aProxyService } from './aim-a2a-proxy.service';
+
+import { GioTestingModule } from '../shared/testing';
+
+describe('AimA2aProxyService', () => {
+  let httpTestingController: HttpTestingController;
+  let service: AimA2aProxyService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [GioTestingModule],
+    });
+
+    httpTestingController = TestBed.inject(HttpTestingController);
+    service = TestBed.inject(AimA2aProxyService);
+  });
+
+  afterEach(() => {
+    httpTestingController.verify();
+  });
+
+  it('should get an A2A proxy from the AIM module', done => {
+    service.getA2aProxy('api-1').subscribe(response => {
+      expect(response.agentId).toBe('catalog-agent-1');
+      done();
+    });
+
+    const req = httpTestingController.expectOne(
+      'https://url.test:3000/gamma/organizations/organization-id/environments/DEFAULT/modules/aim/a2a-proxies/api-1',
+    );
+    expect(req.request.method).toEqual('GET');
+    req.flush({ agentId: 'catalog-agent-1' });
+  });
+});

--- a/gravitee-apim-console-webui/src/services-ngx/aim-a2a-proxy.service.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/aim-a2a-proxy.service.ts
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { HttpClient } from '@angular/common/http';
+import { inject, Injectable } from '@angular/core';
+import { Observable } from 'rxjs';
+
+import { Constants } from '../entities/Constants';
+
+export interface AimA2aProxyDetail {
+  agentId?: string | null;
+}
+
+@Injectable({
+  providedIn: 'root',
+})
+export class AimA2aProxyService {
+  private readonly http = inject(HttpClient);
+  private readonly constants = inject(Constants);
+
+  getA2aProxy(apiId: string): Observable<AimA2aProxyDetail> {
+    return this.http.get<AimA2aProxyDetail>(`${this.aimBaseUrl()}/a2a-proxies/${encodeURIComponent(apiId)}`);
+  }
+
+  private aimBaseUrl(): string {
+    const orgBase = this.constants.org.baseURL;
+    const hostEnd = orgBase.indexOf('/management');
+    const host = hostEnd >= 0 ? orgBase.substring(0, hostEnd) : orgBase;
+    return `${host}/gamma/organizations/${this.constants.org.id}/environments/${this.constants.org.currentEnv.id}/modules/aim`;
+  }
+}

--- a/gravitee-apim-portal-webui-next/src/app/documentation/components/agent-detail/agent-detail.component.html
+++ b/gravitee-apim-portal-webui-next/src/app/documentation/components/agent-detail/agent-detail.component.html
@@ -88,9 +88,9 @@
     }
 
     <!-- I/O Modes -->
-    @if (hasIoModes()) {
-      <section class="agent-detail__section">
-        <h2 class="next-gen-h5 agent-detail__section-title" i18n="@@agentDetailIoModes">Input / Output</h2>
+    <section class="agent-detail__section">
+      <h2 class="next-gen-h5 agent-detail__section-title" i18n="@@agentDetailIoModes">Input / Output</h2>
+      @if (hasIoModes()) {
         <dl class="agent-detail__definition-list">
           @if (hasInputModes()) {
             <div class="agent-detail__definition-row">
@@ -117,16 +117,21 @@
             </div>
           }
         </dl>
-      </section>
-    }
+      } @else {
+        <div class="agent-detail__empty" role="status">
+          <mat-icon aria-hidden="true">swap_horiz</mat-icon>
+          <p class="next-gen-body" i18n="@@agentDetailIoModesEmpty">This agent has not declared default input or output modes.</p>
+        </div>
+      }
+    </section>
 
     <!-- Skills -->
-    @if (skills().length > 0) {
-      <section class="agent-detail__section">
-        <h2 class="next-gen-h5 agent-detail__section-title">
-          <span i18n="@@agentDetailSkills">Skills</span>
-          <span class="agent-detail__section-count">({{ skills().length }})</span>
-        </h2>
+    <section class="agent-detail__section">
+      <h2 class="next-gen-h5 agent-detail__section-title">
+        <span i18n="@@agentDetailSkills">Skills</span>
+        <span class="agent-detail__section-count">({{ skills().length }})</span>
+      </h2>
+      @if (skills().length > 0) {
         <div class="agent-detail__skills-grid">
           @for (skill of skills(); track skill.id) {
             <div class="agent-detail__skill-card">
@@ -166,8 +171,13 @@
             </div>
           }
         </div>
-      </section>
-    }
+      } @else {
+        <div class="agent-detail__empty" role="status">
+          <mat-icon aria-hidden="true">extension</mat-icon>
+          <p class="next-gen-body" i18n="@@agentDetailSkillsEmpty">This agent has not published any skills.</p>
+        </div>
+      }
+    </section>
 
     <!-- Metadata -->
     @if (metadataEntries().length > 0) {

--- a/gravitee-apim-portal-webui-next/src/app/documentation/components/agent-detail/agent-detail.component.scss
+++ b/gravitee-apim-portal-webui-next/src/app/documentation/components/agent-detail/agent-detail.component.scss
@@ -222,6 +222,27 @@
     }
   }
 
+  &__empty {
+    display: flex;
+    align-items: flex-start;
+    gap: 12px;
+    margin: 0;
+    padding: 16px;
+    border: 1px solid app-theme.$border-color;
+    border-radius: app-theme.$container-shape;
+    background: app-theme.$card-background-color;
+    color: app-theme.$paragraph-color;
+
+    mat-icon {
+      flex-shrink: 0;
+      color: app-theme.$chip-label-text-color;
+    }
+
+    p {
+      margin: 0;
+    }
+  }
+
   // Skills
   &__skills-grid {
     display: flex;

--- a/gravitee-apim-portal-webui-next/src/app/documentation/components/agent-detail/agent-detail.component.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/app/documentation/components/agent-detail/agent-detail.component.spec.ts
@@ -69,11 +69,12 @@ function fakeAgent(overrides?: Partial<AgentCatalogItem>): AgentCatalogItem {
 }
 
 @Component({
-  template: '<app-agent-detail [title]="title" [orgId]="orgId" [envId]="envId" />',
+  template: '<app-agent-detail [title]="title" [agentId]="agentId" [orgId]="orgId" [envId]="envId" />',
   imports: [AgentDetailComponent],
 })
 class TestHostComponent {
   title = 'Test Agent';
+  agentId: string | undefined;
   orgId = 'DEFAULT';
   envId = 'DEFAULT';
 }
@@ -82,7 +83,7 @@ describe('AgentDetailComponent', () => {
   let fixture: ComponentFixture<TestHostComponent>;
   let http: HttpTestingController;
 
-  async function setup(agent: AgentCatalogItem | null = fakeAgent()) {
+  async function setup(agent: AgentCatalogItem | null = fakeAgent(), options: { agentId?: string; fail?: boolean } = {}) {
     await TestBed.configureTestingModule({
       imports: [TestHostComponent, MatIconTestingModule],
       providers: [
@@ -96,14 +97,28 @@ describe('AgentDetailComponent', () => {
 
     fixture = TestBed.createComponent(TestHostComponent);
     http = TestBed.inject(HttpTestingController);
+    fixture.componentInstance.agentId = options.agentId;
 
     fixture.detectChanges();
 
-    const req = http.expectOne(r => r.url.includes('/agents') && r.params.get('q') === 'Test Agent');
-    req.flush({
-      data: agent ? [agent] : [],
-      pagination: { page: 1, perPage: 5, pageCount: agent ? 1 : 0, totalCount: agent ? 1 : 0 },
-    });
+    if (options.agentId) {
+      const req = http.expectOne(`${TESTING_BASE_URL}/agents/${options.agentId}`);
+      if (options.fail) {
+        req.flush('Not found', { status: 404, statusText: 'Not Found' });
+      } else {
+        req.flush(agent);
+      }
+    } else {
+      const req = http.expectOne(r => r.url.includes('/agents') && r.params.get('q') === 'Test Agent');
+      if (options.fail) {
+        req.flush('Server error', { status: 500, statusText: 'Internal Server Error' });
+      } else {
+        req.flush({
+          data: agent ? [agent] : [],
+          pagination: { page: 1, perPage: 5, pageCount: agent ? 1 : 0, totalCount: agent ? 1 : 0 },
+        });
+      }
+    }
 
     await fixture.whenStable();
     fixture.detectChanges();
@@ -204,36 +219,51 @@ describe('AgentDetailComponent', () => {
     expect(el.querySelector('.agent-detail__capability-chip')).toBeFalsy();
   });
 
+  it('should show empty states when the agent has no skills or I/O modes', async () => {
+    const agent = fakeAgent();
+    agent.definition.skills = [];
+    agent.definition.defaultInputModes = [];
+    agent.definition.defaultOutputModes = [];
+    await setup(agent);
+
+    const el = fixture.nativeElement as HTMLElement;
+    const emptyStates = Array.from(el.querySelectorAll('.agent-detail__empty p')).map(p => p.textContent?.trim());
+    expect(emptyStates).toContain('This agent has not declared default input or output modes.');
+    expect(emptyStates).toContain('This agent has not published any skills.');
+    expect(el.querySelector('.agent-detail__skill-card')).toBeFalsy();
+    expect(el.querySelector('.agent-detail__mode-chip')).toBeFalsy();
+  });
+
   it('should look up the agent by name search', async () => {
     await setup();
     const el = fixture.nativeElement as HTMLElement;
     expect(el.querySelector('.agent-detail__hero__name')?.textContent?.trim()).toBe('Test Agent');
   });
 
-  it('should show fallback details when the catalog request fails', async () => {
-    await TestBed.configureTestingModule({
-      imports: [TestHostComponent, MatIconTestingModule],
-      providers: [
-        provideHttpClient(),
-        provideHttpClientTesting(),
-        provideNoopAnimations(),
-        provideRouter([]),
-        { provide: ConfigService, useValue: { baseURL: TESTING_BASE_URL } },
-      ],
-    }).compileComponents();
+  it('should look up the agent by id when agentId is provided', async () => {
+    await setup(fakeAgent(), { agentId: 'agent-1' });
+    const el = fixture.nativeElement as HTMLElement;
+    expect(el.querySelector('.agent-detail__hero__name')?.textContent?.trim()).toBe('Test Agent');
+    expect(el.querySelector('.agent-detail__hero__description')?.textContent?.trim()).toBe('A test agent for unit tests.');
+  });
 
-    fixture = TestBed.createComponent(TestHostComponent);
-    http = TestBed.inject(HttpTestingController);
-
-    fixture.detectChanges();
-
-    const req = http.expectOne(r => r.url.includes('/agents') && r.params.get('q') === 'Test Agent');
-    req.flush('Server error', { status: 500, statusText: 'Internal Server Error' });
-
-    await fixture.whenStable();
-    fixture.detectChanges();
+  it('should show the navigation title without dummy details when the catalog request fails', async () => {
+    await setup(null, { fail: true });
 
     const el = fixture.nativeElement as HTMLElement;
     expect(el.querySelector('.agent-detail__hero__name')?.textContent?.trim()).toBe('Test Agent');
+    expect(el.querySelector('.agent-detail__hero__description')).toBeFalsy();
+    expect(el.querySelector('.agent-detail__skill-card')).toBeFalsy();
+    expect(el.querySelectorAll('.agent-detail__empty').length).toBe(2);
+  });
+
+  it('should show the navigation title without dummy details when the agent id lookup fails', async () => {
+    await setup(null, { agentId: 'agent-1', fail: true });
+
+    const el = fixture.nativeElement as HTMLElement;
+    expect(el.querySelector('.agent-detail__hero__name')?.textContent?.trim()).toBe('Test Agent');
+    expect(el.querySelector('.agent-detail__hero__description')).toBeFalsy();
+    expect(el.querySelector('.agent-detail__skill-card')).toBeFalsy();
+    expect(el.querySelectorAll('.agent-detail__empty').length).toBe(2);
   });
 });

--- a/gravitee-apim-portal-webui-next/src/app/documentation/components/agent-detail/agent-detail.component.ts
+++ b/gravitee-apim-portal-webui-next/src/app/documentation/components/agent-detail/agent-detail.component.ts
@@ -33,25 +33,19 @@ import { AgentCatalogService } from '../../../../services/agent-catalog.service'
   styleUrl: './agent-detail.component.scss',
 })
 export class AgentDetailComponent {
-  // TODO: Remove FALLBACK_METADATA once the Gamma catalog agent is linked to the navigation item.
-  // Temporary dummy data used until the real agent definition is available.
-  private static readonly FALLBACK_METADATA: Record<string, string> = {
-    protocol: 'A2A (Agent-to-Agent)',
-    runtime: 'Gravitee AI Gateway',
-    'max-tokens': '8 192',
-    'rate-limit': '60 req / min',
-    region: 'eu-west-1',
-  };
-
   private readonly agentCatalogService = inject(AgentCatalogService);
 
   title = input<string>();
+  agentId = input<string>();
   orgId = input.required<string>();
   envId = input.required<string>();
 
-  agent = rxResource<AgentCatalogItem | null, { title?: string; orgId: string; envId: string }>({
-    params: computed(() => ({ title: this.title(), orgId: this.orgId(), envId: this.envId() })),
+  agent = rxResource<AgentCatalogItem | null, { agentId?: string; title?: string; orgId: string; envId: string }>({
+    params: computed(() => ({ agentId: this.agentId(), title: this.title(), orgId: this.orgId(), envId: this.envId() })),
     stream: ({ params }) => {
+      if (params.agentId) {
+        return this.agentCatalogService.getAgent(params.agentId).pipe(catchError(() => of(null)));
+      }
       if (!params.orgId || !params.envId) {
         return of(null);
       }
@@ -62,67 +56,16 @@ export class AgentDetailComponent {
     },
   });
 
-  // TODO: Remove fallbackDefinition once the Gamma catalog agent is linked to the navigation item.
-  // Temporary dummy data used until the real agent definition is available.
-  private readonly fallbackDefinition = computed<AgentDefinition>(() => ({
-    name: this.title() ?? '',
-    description:
-      'An AI-powered agent that understands your API ecosystem. It can answer questions about API specifications, ' +
-      'assist with subscription configuration, generate code snippets for popular languages, and provide ' +
-      'real-time guidance on rate limits, quotas, and best practices — all through the A2A protocol.',
-    url: 'https://agents.gravitee.io/a2a',
-    version: '2.1.0',
-    documentationUrl: 'https://documentation.gravitee.io/apim/agents',
-    provider: { organization: 'Gravitee.io', url: 'https://gravitee.io' },
-    capabilities: { streaming: true, pushNotifications: true, stateTransitionHistory: true },
-    defaultInputModes: ['text', 'file'],
-    defaultOutputModes: ['text', 'file'],
-    skills: [
-      {
-        id: 'skill-api-explorer',
-        name: 'API Explorer',
-        description:
-          'Navigates and explains OpenAPI / AsyncAPI specifications. Summarizes endpoints, schemas, and authentication requirements.',
-        tags: ['openapi', 'asyncapi', 'discovery'],
-        examples: ['List all POST endpoints in the Payments API', 'What authentication does the Orders API require?'],
-      },
-      {
-        id: 'skill-subscription-helper',
-        name: 'Subscription Helper',
-        description: 'Guides you through API plan selection, subscription creation, and key management.',
-        tags: ['subscription', 'plans', 'keys'],
-        examples: ['Which plan fits 10 000 requests per day?', 'How do I rotate my API key?'],
-      },
-      {
-        id: 'skill-code-gen',
-        name: 'Code Generator',
-        description: 'Produces ready-to-run code snippets for calling APIs in multiple languages and frameworks.',
-        tags: ['codegen', 'sdk', 'integration'],
-        examples: ['Generate a Python requests call for POST /orders', 'Show me a cURL for the health-check endpoint'],
-        inputModes: ['text'],
-        outputModes: ['text', 'file'],
-      },
-      {
-        id: 'skill-troubleshoot',
-        name: 'Troubleshooter',
-        description: 'Diagnoses common API errors (4xx / 5xx), rate-limit issues, and policy misconfigurations.',
-        tags: ['debug', 'errors', 'rate-limit'],
-        examples: ['Why am I getting a 429 on /payments?', 'Explain this CORS error'],
-      },
-    ],
-  }));
-
-  definition = computed(() => (!this.agent.error() ? this.agent.value()?.definition : undefined) ?? this.fallbackDefinition());
+  definition = computed(
+    () => (!this.agent.error() ? this.agent.value()?.definition : undefined) ?? this.emptyDefinition(this.title() ?? ''),
+  );
   provider = computed(() => this.definition()?.provider ?? null);
   capabilities = computed(() => this.definition()?.capabilities ?? null);
   skills = computed(() => this.definition()?.skills ?? []);
 
   metadata = computed(() => {
     const agentValue = !this.agent.error() ? this.agent.value() : undefined;
-    if (agentValue?.definition) {
-      return agentValue.metadata ?? null;
-    }
-    return AgentDetailComponent.FALLBACK_METADATA;
+    return agentValue?.metadata ?? null;
   });
 
   hasAnyCapability = computed(() => {
@@ -160,6 +103,18 @@ export class AgentDetailComponent {
 
   safeDocumentationUrl = computed(() => this.sanitizeUrl(this.definition()?.documentationUrl));
   safeProviderUrl = computed(() => this.sanitizeUrl(this.provider()?.url));
+
+  private emptyDefinition(name: string): AgentDefinition {
+    return {
+      name,
+      url: '',
+      version: '',
+      capabilities: {},
+      defaultInputModes: [],
+      defaultOutputModes: [],
+      skills: [],
+    };
+  }
 
   private sanitizeUrl(url: string | undefined | null): string | null {
     if (!url) return null;

--- a/gravitee-apim-portal-webui-next/src/app/documentation/components/documentation-folder/documentation-folder.component.html
+++ b/gravitee-apim-portal-webui-next/src/app/documentation/components/documentation-folder/documentation-folder.component.html
@@ -79,6 +79,7 @@
       <app-agent-detail
         animate.enter="documentation-folder__main-content-enter"
         [title]="agent.title"
+        [agentId]="agent.agentId"
         [orgId]="agent.organizationId"
         [envId]="agent.environmentId"
       />

--- a/gravitee-apim-portal-webui-next/src/services/agent-catalog.service.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/services/agent-catalog.service.spec.ts
@@ -160,4 +160,37 @@ describe('AgentCatalogService', () => {
       req.flush(mockResponse);
     });
   });
+
+  describe('getAgent', () => {
+    it('should call the portal agent endpoint', () => {
+      const mockAgent = {
+        id: 'agent-1',
+        kind: 'agent' as const,
+        sourceId: 'src-1',
+        sourceKind: 'manual',
+        environmentId: 'DEFAULT',
+        organizationId: 'DEFAULT',
+        creationDate: '2026-04-20T10:00:00Z',
+        updateDate: '2026-04-22T11:00:00Z',
+        definition: {
+          name: 'Test Agent',
+          url: 'https://agents.test/a2a',
+          version: '1.0.0',
+          capabilities: {},
+          skills: [],
+          defaultInputModes: [],
+          defaultOutputModes: [],
+        },
+      };
+
+      service.getAgent('agent-1').subscribe(result => {
+        expect(result.id).toBe('agent-1');
+        expect(result.definition.name).toBe('Test Agent');
+      });
+
+      const req = httpMock.expectOne(`${TESTING_BASE_URL}/agents/agent-1`);
+      expect(req.request.method).toBe('GET');
+      req.flush(mockAgent);
+    });
+  });
 });

--- a/gravitee-apim-portal-webui-next/src/services/agent-catalog.service.ts
+++ b/gravitee-apim-portal-webui-next/src/services/agent-catalog.service.ts
@@ -41,6 +41,10 @@ export class AgentCatalogService {
     return this.searchAgents(orgId, envId, agentName).pipe(map(page => page.data?.find(a => a.definition?.name === agentName) ?? null));
   }
 
+  getAgent(agentId: string): Observable<AgentCatalogItem> {
+    return this.http.get<AgentCatalogItem>(`${this.configService.baseURL}/agents/${encodeURIComponent(agentId)}`);
+  }
+
   /**
    * Derives the Gamma catalog API base URL from the portal base URL.
    *

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/mapper/AgentMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/mapper/AgentMapper.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.portal.rest.mapper;
+
+import io.gravitee.apim.core.agent.model.PortalAgentCard;
+import io.gravitee.rest.api.portal.rest.model.AgentCard;
+import org.mapstruct.Mapper;
+import org.mapstruct.factory.Mappers;
+
+@Mapper(uses = { DateMapper.class })
+public interface AgentMapper {
+    AgentMapper INSTANCE = Mappers.getMapper(AgentMapper.class);
+
+    AgentCard map(PortalAgentCard agent);
+
+    default AgentCard.KindEnum map(String kind) {
+        return kind == null ? AgentCard.KindEnum.AGENT : AgentCard.KindEnum.fromValue(kind);
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/AgentsResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/AgentsResource.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.portal.rest.resource;
+
+import static io.gravitee.rest.api.service.common.GraviteeContext.getExecutionContext;
+
+import io.gravitee.apim.core.agent.use_case.GetPortalAgentUseCase;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationItemViewerContext;
+import io.gravitee.common.http.MediaType;
+import io.gravitee.rest.api.portal.rest.mapper.AgentMapper;
+import io.gravitee.rest.api.portal.rest.security.RequirePortalAuth;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.Response;
+
+public class AgentsResource extends AbstractResource {
+
+    private static final AgentMapper agentMapper = AgentMapper.INSTANCE;
+
+    @Inject
+    private GetPortalAgentUseCase getPortalAgentUseCase;
+
+    @GET
+    @Path("{agentId}")
+    @Produces(MediaType.APPLICATION_JSON)
+    @RequirePortalAuth
+    public Response getAgentByAgentId(@PathParam("agentId") String agentId) {
+        var executionContext = getExecutionContext();
+        var output = getPortalAgentUseCase.execute(
+            new GetPortalAgentUseCase.Input(
+                executionContext.getEnvironmentId(),
+                agentId,
+                PortalNavigationItemViewerContext.forPortal(getAuthenticatedUserOrNull())
+            )
+        );
+
+        return Response.ok(agentMapper.map(output.agent())).build();
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/EnvironmentsResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/EnvironmentsResource.java
@@ -42,6 +42,11 @@ public class EnvironmentsResource extends AbstractResource {
         return resourceContext.getResource(ApiProductResource.class);
     }
 
+    @Path("agents")
+    public AgentsResource getAgentsResource() {
+        return resourceContext.getResource(AgentsResource.class);
+    }
+
     @Path("applications")
     public ApplicationsResource getApplicationsResource() {
         return resourceContext.getResource(ApplicationsResource.class);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/resources/portal-openapi.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/resources/portal-openapi.yaml
@@ -25,6 +25,8 @@ tags:
       description: All about APIs
     - name: Api Product
       description: All about API Products
+    - name: Agent
+      description: All about agents
     - name: Application
       description: All about applications
     - name: Group
@@ -296,6 +298,35 @@ paths:
                                 $ref: "#/components/schemas/ApiProductPlansResponse"
                 404:
                     $ref: "#/components/responses/ApiProductNotFoundError"
+                500:
+                    $ref: "#/components/responses/InternalServerError"
+    /agents/{agentId}:
+        parameters:
+            - $ref: "#/components/parameters/agentIdParam"
+        get:
+            tags:
+                - Agent
+            summary: Get agent card details
+            description: |
+                Get the catalog agent card for an agent exposed in the Developer Portal.
+
+                The agent must be referenced by an accessible, published Portal navigation item,
+                otherwise a 404 is returned. Public agents are visible to anonymous users;
+                private agents require authentication.
+            operationId: getAgentByAgentId
+            security:
+                - {}
+                - BasicAuth: []
+                - CookieAuth: []
+            responses:
+                200:
+                    description: Agent card
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/AgentCard"
+                404:
+                    $ref: "#/components/responses/AgentNotFoundError"
                 500:
                     $ref: "#/components/responses/InternalServerError"
     /apis/{apiId}/informations:
@@ -4187,6 +4218,13 @@ components:
             schema:
                 type: string
                 format: uuid
+        agentIdParam:
+            name: agentId
+            in: path
+            required: true
+            description: Unique identifier of an agent in the Gamma catalog.
+            schema:
+                type: string
         applicationIdParam:
             name: applicationId
             in: path
@@ -5421,6 +5459,148 @@ components:
                     type: array
                     items:
                         $ref: "#/components/schemas/Plan"
+
+        AgentCard:
+            type: object
+            description: Consumer-safe catalog card of an agent exposed in the Developer Portal.
+            required:
+                - id
+                - kind
+                - sourceId
+                - environmentId
+                - organizationId
+                - creationDate
+                - updateDate
+                - definition
+            properties:
+                id:
+                    type: string
+                    description: Unique identifier of the agent in the Gamma catalog.
+                kind:
+                    type: string
+                    description: Catalog kind of the item.
+                    enum:
+                        - agent
+                entityId:
+                    type: string
+                    description: Qualified catalog entity id (`agent.{slug}`).
+                slug:
+                    type: string
+                    description: Catalog slug of the agent.
+                sourceId:
+                    type: string
+                    description: Identifier of the catalog source the agent was imported from.
+                sourceKind:
+                    type: string
+                    description: Kind of the catalog source.
+                environmentId:
+                    type: string
+                    description: Environment the agent belongs to.
+                organizationId:
+                    type: string
+                    description: Organization the agent belongs to.
+                creationDate:
+                    type: string
+                    format: date-time
+                    description: When the agent was created in the catalog.
+                updateDate:
+                    type: string
+                    format: date-time
+                    description: When the agent was last updated in the catalog.
+                metadata:
+                    type: object
+                    additionalProperties:
+                        type: string
+                    description: Agent metadata as key-value pairs.
+                definition:
+                    $ref: "#/components/schemas/AgentCardDefinition"
+
+        AgentCardDefinition:
+            type: object
+            description: A2A agent-card definition shown on the portal agent page.
+            required:
+                - name
+            properties:
+                name:
+                    type: string
+                    description: Display name of the agent.
+                description:
+                    type: string
+                    description: Description of the agent.
+                url:
+                    type: string
+                    description: A2A endpoint URL of the agent.
+                provider:
+                    $ref: "#/components/schemas/AgentCardProvider"
+                version:
+                    type: string
+                    description: Version of the agent card.
+                documentationUrl:
+                    type: string
+                    description: Documentation URL of the agent.
+                capabilities:
+                    $ref: "#/components/schemas/AgentCardCapabilities"
+                defaultInputModes:
+                    type: array
+                    items:
+                        type: string
+                defaultOutputModes:
+                    type: array
+                    items:
+                        type: string
+                skills:
+                    type: array
+                    items:
+                        $ref: "#/components/schemas/AgentCardSkill"
+
+        AgentCardProvider:
+            type: object
+            required:
+                - organization
+            properties:
+                organization:
+                    type: string
+                url:
+                    type: string
+
+        AgentCardCapabilities:
+            type: object
+            properties:
+                streaming:
+                    type: boolean
+                pushNotifications:
+                    type: boolean
+                stateTransitionHistory:
+                    type: boolean
+
+        AgentCardSkill:
+            type: object
+            required:
+                - id
+                - name
+            properties:
+                id:
+                    type: string
+                name:
+                    type: string
+                description:
+                    type: string
+                tags:
+                    type: array
+                    items:
+                        type: string
+                examples:
+                    type: array
+                    items:
+                        type: string
+                inputModes:
+                    type: array
+                    items:
+                        type: string
+                outputModes:
+                    type: array
+                    items:
+                        type: string
 
         PortalApiProductDetails:
             type: object
@@ -8891,6 +9071,12 @@ components:
                         $ref: "#/components/schemas/ErrorResponse"
         ApiProductNotFoundError:
             description: API Product not found
+            content:
+                application/json:
+                    schema:
+                        $ref: "#/components/schemas/ErrorResponse"
+        AgentNotFoundError:
+            description: Agent not found
             content:
                 application/json:
                     schema:

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/AgentsResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/AgentsResourceTest.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.portal.rest.resource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import inmemory.AimCatalogQueryServiceInMemory;
+import inmemory.PortalNavigationItemsQueryServiceInMemory;
+import io.gravitee.apim.core.agent.model.PortalAgentCard;
+import io.gravitee.apim.core.portal.model.PortalArea;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationAgent;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationItemId;
+import io.gravitee.apim.core.portal_page.model.PortalVisibility;
+import io.gravitee.rest.api.portal.rest.model.AgentCard;
+import io.gravitee.rest.api.service.common.GraviteeContext;
+import jakarta.ws.rs.core.Response;
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class AgentsResourceTest extends AbstractResourceTest {
+
+    private static final String ENVIRONMENT_ID = "DEFAULT";
+    private static final String AGENT_ID = "catalog-agent-id";
+    private static final Instant CREATED_AT = Instant.parse("2026-04-20T10:00:00Z");
+    private static final Instant UPDATED_AT = Instant.parse("2026-04-22T11:00:00Z");
+
+    @Autowired
+    private AimCatalogQueryServiceInMemory aimCatalogQueryService;
+
+    @Autowired
+    private PortalNavigationItemsQueryServiceInMemory navigationItemsQueryService;
+
+    @Override
+    protected String contextPath() {
+        return "agents/";
+    }
+
+    @BeforeEach
+    void setUp() {
+        GraviteeContext.setCurrentEnvironment(ENVIRONMENT_ID);
+    }
+
+    @AfterEach
+    void tearDown() {
+        GraviteeContext.cleanContext();
+        aimCatalogQueryService.reset();
+        navigationItemsQueryService.reset();
+    }
+
+    @Test
+    void should_return_agent_card_when_exposed_in_navigation() {
+        navigationItemsQueryService.initWith(List.of(publicAgentNavigationItem()));
+        aimCatalogQueryService.initWith(List.of(agentCard()));
+
+        Response response = target(AGENT_ID).request().get();
+
+        assertThat(response.getStatus()).isEqualTo(Response.Status.OK.getStatusCode());
+        var result = response.readEntity(AgentCard.class);
+        assertThat(result.getId()).isEqualTo(AGENT_ID);
+        assertThat(result.getKind()).isEqualTo(AgentCard.KindEnum.AGENT);
+        assertThat(result.getEntityId()).isEqualTo("agent.weather-agent");
+        assertThat(result.getDefinition().getName()).isEqualTo("Weather Agent");
+        assertThat(result.getDefinition().getSkills()).extracting(skill -> skill.getName()).containsExactly("Forecast");
+        assertThat(result.getMetadata()).containsEntry("protocol", "A2A");
+        assertThat(result.getCreationDate()).isEqualTo(OffsetDateTime.ofInstant(CREATED_AT, ZoneOffset.UTC));
+        assertThat(result.getUpdateDate()).isEqualTo(OffsetDateTime.ofInstant(UPDATED_AT, ZoneOffset.UTC));
+    }
+
+    @Test
+    void should_return_not_found_when_agent_is_not_exposed_in_navigation() {
+        aimCatalogQueryService.initWith(List.of(agentCard()));
+
+        Response response = target(AGENT_ID).request().get();
+
+        assertThat(response.getStatus()).isEqualTo(Response.Status.NOT_FOUND.getStatusCode());
+    }
+
+    private static PortalNavigationAgent publicAgentNavigationItem() {
+        return PortalNavigationAgent.builder()
+            .id(PortalNavigationItemId.of("00000000-0000-0000-0000-000000000201"))
+            .organizationId("organization-id")
+            .environmentId(ENVIRONMENT_ID)
+            .title("Weather Agent")
+            .segment("weather-agent")
+            .area(PortalArea.TOP_NAVBAR)
+            .order(0)
+            .apiId("a2a-proxy-api-id")
+            .agentId(AGENT_ID)
+            .published(true)
+            .visibility(PortalVisibility.PUBLIC)
+            .build();
+    }
+
+    private static PortalAgentCard agentCard() {
+        return new PortalAgentCard(
+            AGENT_ID,
+            PortalAgentCard.KIND_AGENT,
+            "agent.weather-agent",
+            "weather-agent",
+            "source-id",
+            "manual",
+            ENVIRONMENT_ID,
+            "organization-id",
+            CREATED_AT,
+            UPDATED_AT,
+            Map.of("protocol", "A2A"),
+            new PortalAgentCard.Definition(
+                "Weather Agent",
+                "Forecasts the weather",
+                "https://agents.example/a2a",
+                new PortalAgentCard.Provider("Gravitee", "https://gravitee.io"),
+                "1.0.0",
+                "https://docs.example",
+                new PortalAgentCard.Capabilities(true, false, true),
+                List.of("text"),
+                List.of("text"),
+                List.of(new PortalAgentCard.Skill("skill-forecast", "Forecast", "Tell the weather", List.of("weather"), List.of(), List.of(), List.of()))
+            )
+        );
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/agent/exception/PortalAgentNotFoundException.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/agent/exception/PortalAgentNotFoundException.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.agent.exception;
+
+import io.gravitee.apim.core.exception.NotFoundDomainException;
+
+public class PortalAgentNotFoundException extends NotFoundDomainException {
+
+    public PortalAgentNotFoundException(String id) {
+        super("Agent not found.", id);
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/agent/model/PortalAgentCard.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/agent/model/PortalAgentCard.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.agent.model;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+
+public record PortalAgentCard(
+    String id,
+    String kind,
+    String entityId,
+    String slug,
+    String sourceId,
+    String sourceKind,
+    String environmentId,
+    String organizationId,
+    Instant creationDate,
+    Instant updateDate,
+    Map<String, String> metadata,
+    Definition definition
+) {
+    public static final String KIND_AGENT = "agent";
+
+    public PortalAgentCard {
+        metadata = metadata == null ? Map.of() : Map.copyOf(metadata);
+    }
+
+    public record Definition(
+        String name,
+        String description,
+        String url,
+        Provider provider,
+        String version,
+        String documentationUrl,
+        Capabilities capabilities,
+        List<String> defaultInputModes,
+        List<String> defaultOutputModes,
+        List<Skill> skills
+    ) {
+        public Definition {
+            defaultInputModes = defaultInputModes == null ? List.of() : List.copyOf(defaultInputModes);
+            defaultOutputModes = defaultOutputModes == null ? List.of() : List.copyOf(defaultOutputModes);
+            skills = skills == null ? List.of() : List.copyOf(skills);
+        }
+    }
+
+    public record Provider(String organization, String url) {}
+
+    public record Capabilities(Boolean streaming, Boolean pushNotifications, Boolean stateTransitionHistory) {}
+
+    public record Skill(
+        String id,
+        String name,
+        String description,
+        List<String> tags,
+        List<String> examples,
+        List<String> inputModes,
+        List<String> outputModes
+    ) {
+        public Skill {
+            tags = tags == null ? List.of() : List.copyOf(tags);
+            examples = examples == null ? List.of() : List.copyOf(examples);
+            inputModes = inputModes == null ? List.of() : List.copyOf(inputModes);
+            outputModes = outputModes == null ? List.of() : List.copyOf(outputModes);
+        }
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/agent/service_provider/AimCatalogQueryService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/agent/service_provider/AimCatalogQueryService.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.agent.service_provider;
+
+import io.gravitee.apim.core.agent.model.PortalAgentCard;
+import java.util.Optional;
+
+public interface AimCatalogQueryService {
+    Optional<PortalAgentCard> findById(String environmentId, String agentId);
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/agent/use_case/GetPortalAgentUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/agent/use_case/GetPortalAgentUseCase.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.agent.use_case;
+
+import io.gravitee.apim.core.UseCase;
+import io.gravitee.apim.core.agent.exception.PortalAgentNotFoundException;
+import io.gravitee.apim.core.agent.model.PortalAgentCard;
+import io.gravitee.apim.core.agent.service_provider.AimCatalogQueryService;
+import io.gravitee.apim.core.portal_page.domain_service.PortalAgentAccessDomainService;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationItemViewerContext;
+import lombok.RequiredArgsConstructor;
+
+@UseCase
+@RequiredArgsConstructor
+public class GetPortalAgentUseCase {
+
+    private final PortalAgentAccessDomainService portalAgentAccessDomainService;
+    private final AimCatalogQueryService aimCatalogQueryService;
+
+    public Output execute(Input input) {
+        portalAgentAccessDomainService.findAccessible(input.environmentId(), input.agentId(), input.viewerContext());
+        var agent = aimCatalogQueryService
+            .findById(input.environmentId(), input.agentId())
+            .orElseThrow(() -> new PortalAgentNotFoundException(input.agentId()));
+        return new Output(agent);
+    }
+
+    public record Input(String environmentId, String agentId, PortalNavigationItemViewerContext viewerContext) {}
+
+    public record Output(PortalAgentCard agent) {}
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/PortalAgentAccessDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/PortalAgentAccessDomainService.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.portal_page.domain_service;
+
+import io.gravitee.apim.core.DomainService;
+import io.gravitee.apim.core.agent.exception.PortalAgentNotFoundException;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationAgent;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationItemQueryCriteria;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationItemType;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationItemViewerContext;
+import io.gravitee.apim.core.portal_page.query_service.PortalNavigationItemsQueryService;
+import java.util.Set;
+import lombok.RequiredArgsConstructor;
+
+@DomainService
+@RequiredArgsConstructor
+public class PortalAgentAccessDomainService {
+
+    private final PortalNavigationItemsQueryService portalNavigationItemsQueryService;
+    private final PortalNavigationApiVisibilityDomainService apiVisibilityDomainService;
+
+    public PortalNavigationAgent findAccessible(String environmentId, String agentId, PortalNavigationItemViewerContext viewerContext) {
+        Set<String> accessibleAgentApiIds = apiVisibilityDomainService.resolveAccessibleAgentApiIds(environmentId, viewerContext);
+
+        return portalNavigationItemsQueryService
+            .search(
+                PortalNavigationItemQueryCriteria.builder()
+                    .environmentId(environmentId)
+                    .published(true)
+                    .type(PortalNavigationItemType.AGENT)
+                    .agentIds(Set.of(agentId))
+                    .build()
+            )
+            .stream()
+            .filter(PortalNavigationAgent.class::isInstance)
+            .map(PortalNavigationAgent.class::cast)
+            .filter(item -> !viewerContext.shouldNotShow(item))
+            .filter(item -> !apiVisibilityDomainService.isAgentItemHidden(item, viewerContext, accessibleAgentApiIds))
+            .filter(item -> !apiVisibilityDomainService.hasHiddenApiAncestor(environmentId, item, viewerContext))
+            .findFirst()
+            .orElseThrow(() -> new PortalAgentNotFoundException(agentId));
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/agent/AimCatalogQueryServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/agent/AimCatalogQueryServiceImpl.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.infra.agent;
+
+import io.gravitee.apim.core.agent.model.PortalAgentCard;
+import io.gravitee.apim.core.agent.service_provider.AimCatalogQueryService;
+import java.util.Optional;
+import lombok.CustomLog;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.Primary;
+import org.springframework.stereotype.Service;
+
+@Service
+@Primary
+@CustomLog
+@RequiredArgsConstructor
+public class AimCatalogQueryServiceImpl implements AimCatalogQueryService {
+
+    private final ApplicationContext applicationContext;
+
+    private volatile AimCatalogQueryService delegate;
+
+    @Override
+    public Optional<PortalAgentCard> findById(String environmentId, String agentId) {
+        var catalog = resolveDelegate();
+        if (catalog == null) {
+            log.debug("AIM catalog is not available; agent [{}] cannot be loaded", agentId);
+            return Optional.empty();
+        }
+        return catalog.findById(environmentId, agentId);
+    }
+
+    private AimCatalogQueryService resolveDelegate() {
+        if (delegate != null) {
+            return delegate;
+        }
+        var found = applicationContext
+            .getBeansOfType(AimCatalogQueryService.class)
+            .values()
+            .stream()
+            .filter(service -> service != this)
+            .findFirst()
+            .orElse(null);
+        if (found != null) {
+            delegate = found;
+        }
+        return found;
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/AimCatalogQueryServiceInMemory.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/AimCatalogQueryServiceInMemory.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package inmemory;
+
+import io.gravitee.apim.core.agent.model.PortalAgentCard;
+import io.gravitee.apim.core.agent.service_provider.AimCatalogQueryService;
+import java.util.Objects;
+import java.util.Optional;
+
+public class AimCatalogQueryServiceInMemory extends AbstractQueryServiceInMemory<PortalAgentCard> implements AimCatalogQueryService {
+
+    @Override
+    public Optional<PortalAgentCard> findById(String environmentId, String agentId) {
+        return storage
+            .stream()
+            .filter(agent -> Objects.equals(agentId, agent.id()) && Objects.equals(environmentId, agent.environmentId()))
+            .findFirst();
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/spring/InMemoryConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/spring/InMemoryConfiguration.java
@@ -516,6 +516,11 @@ public class InMemoryConfiguration {
     }
 
     @Bean
+    public AimCatalogQueryServiceInMemory aimCatalogQueryService() {
+        return new AimCatalogQueryServiceInMemory();
+    }
+
+    @Bean
     public NewtAIProvider newtAIProvider() {
         return new NewtAIProviderInMemory();
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/agent/use_case/GetPortalAgentUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/agent/use_case/GetPortalAgentUseCaseTest.java
@@ -1,0 +1,215 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.agent.use_case;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import fixtures.core.model.PortalNavigationItemFixtures;
+import inmemory.AimCatalogQueryServiceInMemory;
+import inmemory.ApiQueryServiceInMemory;
+import inmemory.MembershipQueryServiceInMemory;
+import inmemory.PortalNavigationItemsQueryServiceInMemory;
+import inmemory.SubscriptionQueryServiceInMemory;
+import io.gravitee.apim.core.agent.exception.PortalAgentNotFoundException;
+import io.gravitee.apim.core.agent.model.PortalAgentCard;
+import io.gravitee.apim.core.membership.domain_service.ApiPortalMembershipDomainService;
+import io.gravitee.apim.core.membership.model.Membership;
+import io.gravitee.apim.core.portal_page.domain_service.PortalAgentAccessDomainService;
+import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationApiVisibilityDomainService;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationAgent;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationItemViewerContext;
+import io.gravitee.apim.core.portal_page.model.PortalVisibility;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class GetPortalAgentUseCaseTest {
+
+    private static final String ENVIRONMENT_ID = PortalNavigationItemFixtures.ENV_ID;
+    private static final String AGENT_ID = "catalog-agent-id";
+    private static final String API_ID = "a2a-proxy-api-id";
+    private static final String USER_ID = "user-id";
+    private static final Instant CREATED_AT = Instant.parse("2026-04-20T10:00:00Z");
+    private static final Instant UPDATED_AT = Instant.parse("2026-04-22T11:00:00Z");
+
+    private AimCatalogQueryServiceInMemory aimCatalogQueryService;
+    private MembershipQueryServiceInMemory membershipQueryService;
+    private PortalNavigationItemsQueryServiceInMemory navigationItemsQueryService;
+    private GetPortalAgentUseCase useCase;
+
+    @BeforeEach
+    void setUp() {
+        aimCatalogQueryService = new AimCatalogQueryServiceInMemory();
+        membershipQueryService = new MembershipQueryServiceInMemory();
+        navigationItemsQueryService = new PortalNavigationItemsQueryServiceInMemory();
+
+        var apiMembershipDomainService = new ApiPortalMembershipDomainService(
+            membershipQueryService,
+            new SubscriptionQueryServiceInMemory(),
+            new ApiQueryServiceInMemory()
+        );
+        var apiVisibilityDomainService = new PortalNavigationApiVisibilityDomainService(
+            navigationItemsQueryService,
+            apiMembershipDomainService
+        );
+        useCase = new GetPortalAgentUseCase(
+            new PortalAgentAccessDomainService(navigationItemsQueryService, apiVisibilityDomainService),
+            aimCatalogQueryService
+        );
+    }
+
+    @Test
+    void should_return_public_agent_card_when_exposed_in_navigation() {
+        givenPublicAgent();
+        aimCatalogQueryService.initWith(List.of(agentCard()));
+
+        var result = useCase.execute(input(null)).agent();
+
+        assertThat(result.id()).isEqualTo(AGENT_ID);
+        assertThat(result.kind()).isEqualTo(PortalAgentCard.KIND_AGENT);
+        assertThat(result.definition().name()).isEqualTo("Weather Agent");
+        assertThat(result.definition().skills()).extracting(PortalAgentCard.Skill::name).containsExactly("Forecast");
+        assertThat(result.metadata()).containsEntry("protocol", "A2A");
+    }
+
+    @Test
+    void should_return_private_agent_to_direct_member() {
+        var navigationItem = publicAgentNavigationItem();
+        navigationItem.setVisibility(PortalVisibility.PRIVATE);
+        navigationItemsQueryService.initWith(List.of(navigationItem));
+        membershipQueryService.initWith(List.of(apiMembership(USER_ID)));
+        aimCatalogQueryService.initWith(List.of(agentCard()));
+
+        var result = useCase.execute(input(USER_ID));
+
+        assertThat(result.agent().id()).isEqualTo(AGENT_ID);
+    }
+
+    @Test
+    void should_return_not_found_for_private_agent_without_access() {
+        var navigationItem = publicAgentNavigationItem();
+        navigationItem.setVisibility(PortalVisibility.PRIVATE);
+        navigationItemsQueryService.initWith(List.of(navigationItem));
+        aimCatalogQueryService.initWith(List.of(agentCard()));
+
+        assertThatThrownBy(() -> useCase.execute(input(USER_ID))).isInstanceOf(PortalAgentNotFoundException.class);
+    }
+
+    @Test
+    void should_return_not_found_when_agent_is_not_exposed_in_navigation() {
+        aimCatalogQueryService.initWith(List.of(agentCard()));
+
+        assertThatThrownBy(() -> useCase.execute(input(null))).isInstanceOf(PortalAgentNotFoundException.class);
+    }
+
+    @Test
+    void should_return_not_found_when_navigation_item_is_unpublished() {
+        var navigationItem = publicAgentNavigationItem();
+        navigationItem.setPublished(false);
+        navigationItemsQueryService.initWith(List.of(navigationItem));
+        aimCatalogQueryService.initWith(List.of(agentCard()));
+
+        assertThatThrownBy(() -> useCase.execute(input(null))).isInstanceOf(PortalAgentNotFoundException.class);
+    }
+
+    @Test
+    void should_return_not_found_when_navigation_item_has_no_catalog_agent_id() {
+        var navigationItem = publicAgentNavigationItem();
+        navigationItem.setAgentId(null);
+        navigationItemsQueryService.initWith(List.of(navigationItem));
+        aimCatalogQueryService.initWith(List.of(agentCard()));
+
+        assertThatThrownBy(() -> useCase.execute(input(null))).isInstanceOf(PortalAgentNotFoundException.class);
+    }
+
+    @Test
+    void should_return_not_found_when_catalog_agent_is_missing() {
+        givenPublicAgent();
+
+        assertThatThrownBy(() -> useCase.execute(input(null))).isInstanceOf(PortalAgentNotFoundException.class);
+    }
+
+    @Test
+    void should_return_not_found_when_catalog_agent_belongs_to_another_environment() {
+        givenPublicAgent();
+        aimCatalogQueryService.initWith(List.of(agentCard("other-environment-id")));
+
+        assertThatThrownBy(() -> useCase.execute(input(null))).isInstanceOf(PortalAgentNotFoundException.class);
+    }
+
+    private void givenPublicAgent() {
+        navigationItemsQueryService.initWith(List.of(publicAgentNavigationItem()));
+    }
+
+    private static GetPortalAgentUseCase.Input input(String userId) {
+        return new GetPortalAgentUseCase.Input(ENVIRONMENT_ID, AGENT_ID, PortalNavigationItemViewerContext.forPortal(userId));
+    }
+
+    private static PortalNavigationAgent publicAgentNavigationItem() {
+        return PortalNavigationItemFixtures.anAgent("nav-agent-id", "Weather Agent", null, API_ID)
+            .toBuilder()
+            .agentId(AGENT_ID)
+            .build();
+    }
+
+    private static Membership apiMembership(String userId) {
+        return Membership.builder()
+            .id("api-membership")
+            .memberId(userId)
+            .memberType(Membership.Type.USER)
+            .referenceType(Membership.ReferenceType.API)
+            .referenceId(API_ID)
+            .build();
+    }
+
+    private static PortalAgentCard agentCard() {
+        return agentCard(ENVIRONMENT_ID);
+    }
+
+    private static PortalAgentCard agentCard(String environmentId) {
+        return new PortalAgentCard(
+            AGENT_ID,
+            PortalAgentCard.KIND_AGENT,
+            "agent.weather-agent",
+            "weather-agent",
+            "source-id",
+            "manual",
+            environmentId,
+            "org-id",
+            CREATED_AT,
+            UPDATED_AT,
+            Map.of("protocol", "A2A"),
+            new PortalAgentCard.Definition(
+                "Weather Agent",
+                "Forecasts the weather",
+                "https://agents.example/a2a",
+                new PortalAgentCard.Provider("Gravitee", "https://gravitee.io"),
+                "1.0.0",
+                "https://docs.example",
+                new PortalAgentCard.Capabilities(true, false, true),
+                List.of("text"),
+                List.of("text"),
+                List.of(new PortalAgentCard.Skill("skill-forecast", "Forecast", "Tell the weather", List.of("weather"), List.of(), List.of(), List.of()))
+            )
+        );
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/agent/AimCatalogQueryServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/agent/AimCatalogQueryServiceImplTest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.infra.agent;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.gravitee.apim.core.agent.model.PortalAgentCard;
+import io.gravitee.apim.core.agent.service_provider.AimCatalogQueryService;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.springframework.context.ApplicationContext;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class AimCatalogQueryServiceImplTest {
+
+    @Test
+    void should_return_empty_when_aim_catalog_is_not_registered() {
+        var applicationContext = mock(ApplicationContext.class);
+        var queryService = new AimCatalogQueryServiceImpl(applicationContext);
+        when(applicationContext.getBeansOfType(AimCatalogQueryService.class)).thenReturn(Map.of("self", queryService));
+
+        assertThat(queryService.findById("env", "agent-id")).isEmpty();
+    }
+
+    @Test
+    void should_delegate_to_the_aim_catalog_when_registered() {
+        var applicationContext = mock(ApplicationContext.class);
+        var queryService = new AimCatalogQueryServiceImpl(applicationContext);
+        var aimCatalog = mock(AimCatalogQueryService.class);
+        var agent = agentCard();
+        when(applicationContext.getBeansOfType(AimCatalogQueryService.class)).thenReturn(
+            Map.of("self", queryService, "aim", aimCatalog)
+        );
+        when(aimCatalog.findById("env", "agent-id")).thenReturn(Optional.of(agent));
+
+        assertThat(queryService.findById("env", "agent-id")).contains(agent);
+    }
+
+    private static PortalAgentCard agentCard() {
+        return new PortalAgentCard(
+            "agent-id",
+            PortalAgentCard.KIND_AGENT,
+            "agent.weather",
+            "weather",
+            "source-id",
+            "manual",
+            "env",
+            "org",
+            Instant.parse("2026-04-20T10:00:00Z"),
+            Instant.parse("2026-04-22T11:00:00Z"),
+            Map.of(),
+            new PortalAgentCard.Definition("Weather", null, null, null, "1.0.0", null, null, List.of(), List.of(), List.of())
+        );
+    }
+}


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/AIAM-597

### Description

The Developer Portal agent page was showing placeholder skills and metadata because navigation items never stored a catalog agent id, and the page tried to match Gamma catalog entries by title. This change serves the real agent card through a new Portal API endpoint and records the catalog id when an AGENT item is created, so the page can load by id.

Public agents remain visible to anonymous users. Private agents still require portal authentication and access to the backing A2A proxy, and a missing or hidden agent is returned as 404. Existing items without an agent id keep the previous name search as a fallback.

### Changes

#### Console portal editor

When operators bulk-create AGENT navigation items, the console now loads each selected A2A proxy from AIM and writes the resolved catalog agent id onto the item next to the API id. If that lookup fails, creation still proceeds without the catalog id.

#### Portal API

Adds GET /portal/environments/{envId}/agents/{agentId} and an AgentCard schema. The use case only returns a card when a published, accessible AGENT navigation item references that catalog id, then reads the card through an AIM catalog query port. The infra adapter looks up the AIM implementation at request time so the portal does not call Gamma over HTTP as the current user.

#### Portal Next agent page

The agent detail view takes agentId from the navigation item and calls the new portal endpoint when it is present. Dummy fallback copy is removed. Input/output and skills stay on the page with empty-state copy when the card has none.