### PR TITLE
fix(observability): register HUMAN_APPROVAL_VERDICT in the filter catalog (AIAM-604)

### DIFF
--- a/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/core/observability/filter/model/StaticFilters.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/core/observability/filter/model/StaticFilters.java
@@ -132,6 +132,24 @@ public enum StaticFilters {
 
     AUTHZ_REASON("Reason", FilterType.STRING, Defs.CONTAINS_ONLY, null, null, Defs.LOGS, Defs.DECISION_RECORDS),
 
+    // --- Human approval ---------------------------------------------------------------------------
+    /**
+     * What a reviewer decided on a held call. The same name and ENUM vocabulary the management-v2
+     * analytics engine already advertises (see {@code analytics-definition.yaml}) — the field is
+     * resolved by {@code HumanApprovalFieldResolver} regardless of which surface queries it.
+     * ANALYTICS-only and AGENT-scoped: the only place it is queried today is the agent dashboard's
+     * Human Decision Cost widget.
+     */
+    HUMAN_APPROVAL_VERDICT(
+        "Verdict",
+        FilterType.ENUM,
+        Defs.EQ_IN,
+        Defs.HUMAN_APPROVAL_VERDICTS,
+        null,
+        Defs.ANALYTICS,
+        Set.of(ApiType.AGENT)
+    ),
+
     // --- LLM ------------------------------------------------------------------------------------
     LLM_PROXY_MODEL("LLM Model", FilterType.KEYWORD, Defs.EQ_IN, null, null, Defs.LOGS_ANALYTICS, Set.of(ApiType.LLM)),
     LLM_PROXY_PROVIDER("LLM Provider", FilterType.KEYWORD, Defs.EQ_IN, null, null, Defs.LOGS_ANALYTICS, Set.of(ApiType.LLM)),
@@ -426,6 +444,14 @@ public enum StaticFilters {
             new EnumValue("PERMIT", "Permit"),
             new EnumValue("FORBID", "Forbid"),
             new EnumValue("NOT_APPLICABLE", "Not applicable")
+        );
+
+        private static final List<EnumValue> HUMAN_APPROVAL_VERDICTS = List.of(
+            self("APPROVE"),
+            self("EDIT"),
+            self("REJECT"),
+            self("EXPIRED"),
+            new EnumValue("NO_MATCH", "No match")
         );
 
         /** Enum value whose display label is identical to its wire value. */

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/test/java/io/gravitee/gamma/rest/core/observability/filter/domain_service/ObservabilityFilterValidatorHumanApprovalVerdictTest.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/test/java/io/gravitee/gamma/rest/core/observability/filter/domain_service/ObservabilityFilterValidatorHumanApprovalVerdictTest.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gamma.rest.core.observability.filter.domain_service;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+import io.gravitee.gamma.rest.core.observability.filter.model.FilterCondition;
+import io.gravitee.gamma.rest.core.observability.filter.model.FilterOperator;
+import io.gravitee.gamma.rest.core.observability.filter.model.Signal;
+import io.gravitee.gamma.rest.infra.adapter.SpiFilterRegistry;
+import java.util.List;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+// Real registry, not mocked: the Agent dashboard's Human Decision Cost widget filters on this
+// condition against the ANALYTICS signal (via /gamma/.../observability/analytics/facets) and 400'd
+// with "Filter 'HUMAN_APPROVAL_VERDICT' is not supported by this backend" because the catalog never
+// carried the name, even though HumanApprovalFieldResolver already resolves it.
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class ObservabilityFilterValidatorHumanApprovalVerdictTest {
+
+    private final ObservabilityFilterValidator validator = new ObservabilityFilterValidator(new SpiFilterRegistry());
+
+    @Test
+    void should_accept_human_approval_verdict_in_as_an_analytics_condition() {
+        var conditions = List.of(new FilterCondition("HUMAN_APPROVAL_VERDICT", FilterOperator.IN, List.of("APPROVE", "REJECT", "EDIT")));
+
+        assertThatCode(() -> validator.validate(conditions, Signal.ANALYTICS)).doesNotThrowAnyException();
+    }
+}


### PR DESCRIPTION
## Summary

The Agent dashboard's Human Decision Cost widget filters on `HUMAN_APPROVAL_VERDICT` via `/gamma/.../observability/analytics/facets`, which rejected the condition with `"Filter 'HUMAN_APPROVAL_VERDICT' is not supported by this backend"` (`observability.filter.unknown_name`) even though `HumanApprovalFieldResolver` already resolves the field. It was never registered in `StaticFilters`, the catalog `ObservabilityFilterValidator` checks for that endpoint. It faceted fine (the `by` clause) because faceting and filtering are validated independently — only the explicit filter condition path was missing the entry.

- Adds `HUMAN_APPROVAL_VERDICT` to `StaticFilters` (ENUM, `APPROVE`/`EDIT`/`REJECT`/`EXPIRED`/`NO_MATCH`, `EQ`/`IN`, `Signal.ANALYTICS`, scoped to `ApiType.AGENT`), matching the vocabulary already used by the separate management-v2 analytics catalog and the field resolver.
- Same pattern already used for other module-owned filters in this host catalog (`LLM_PROXY_TOOL`, `MCP_PROXY_TOOL`, `NATIVE_TOPIC`, ...) — there's no live plugin-contribution mechanism for this registry yet, so domain filters are declared here.

