### PR TITLE
fix(rest-api): recover from a promotion insert conflict without re-reading the row (APIM-15024)

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoPromotionRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoPromotionRepository.java
@@ -69,14 +69,17 @@ public class MongoPromotionRepository implements PromotionRepository {
             throw new IllegalStateException("Promotion must not be null");
         }
 
-        return internalRepository
-            .findById(promotion.getId())
-            .map(existingPromotion -> {
-                log.debug("Update promotion [{}]", promotion.getId());
-                return internalRepository.save(map(promotion));
-            })
-            .map(this::map)
-            .orElseThrow(() -> new IllegalStateException(String.format("No promotion found with id [%s]", promotion.getId())));
+        log.debug("Update promotion [{}]", promotion.getId());
+
+        // Whether the promotion exists is decided by the replacement itself rather than by a preceding read: a read
+        // may be served by a lagging secondary and miss a promotion another node has just written, which would
+        // refuse an update the database would have accepted.
+        if (!internalRepository.replace(map(promotion))) {
+            throw new IllegalStateException(String.format("No promotion found with id [%s]", promotion.getId()));
+        }
+
+        log.debug("Update promotion [{}] - Done", promotion.getId());
+        return promotion;
     }
 
     @Override

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/promotion/PromotionMongoRepositoryCustom.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/promotion/PromotionMongoRepositoryCustom.java
@@ -29,4 +29,12 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface PromotionMongoRepositoryCustom {
     Page<PromotionMongo> search(PromotionCriteria criteria, Sortable sortable, Pageable pageable);
+
+    /**
+     * Replaces the stored promotion, reporting whether one was there to replace. The answer comes from the write
+     * itself so that it cannot be given by a read, which may be served by a lagging secondary.
+     *
+     * @return false when no promotion carries that id
+     */
+    boolean replace(PromotionMongo promotion);
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/promotion/PromotionMongoRepositoryImpl.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/promotion/PromotionMongoRepositoryImpl.java
@@ -94,4 +94,9 @@ public class PromotionMongoRepositoryImpl implements PromotionMongoRepositoryCus
 
         return new Page<>(promotions, pageable != null ? pageable.pageNumber() : 0, promotions.size(), total);
     }
+
+    @Override
+    public boolean replace(PromotionMongo promotion) {
+        return mongoTemplate.findAndReplace(Query.query(where("_id").is(promotion.getId())), promotion) != null;
+    }
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/test/java/io/gravitee/repository/mongodb/management/MongoPromotionRepositoryTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/test/java/io/gravitee/repository/mongodb/management/MongoPromotionRepositoryTest.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.mongodb.management;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.gravitee.repository.exceptions.TechnicalException;
+import io.gravitee.repository.management.model.Promotion;
+import io.gravitee.repository.mongodb.management.internal.promotion.PromotionMongoRepository;
+import io.gravitee.repository.mongodb.management.mapper.GraviteeMapper;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class MongoPromotionRepositoryTest {
+
+    private MongoPromotionRepository mongoPromotionRepository;
+    private PromotionMongoRepository internalRepository;
+    private GraviteeMapper mapper;
+
+    @BeforeEach
+    public void setUp() {
+        internalRepository = mock(PromotionMongoRepository.class);
+        mapper = mock(GraviteeMapper.class);
+
+        mongoPromotionRepository = new MongoPromotionRepository();
+
+        // Inject collaborators via reflection (since in production they are autowired)
+        try {
+            var internalField = MongoPromotionRepository.class.getDeclaredField("internalRepository");
+            internalField.setAccessible(true);
+            internalField.set(mongoPromotionRepository, internalRepository);
+
+            var mapperField = MongoPromotionRepository.class.getDeclaredField("mapper");
+            mapperField.setAccessible(true);
+            mapperField.set(mongoPromotionRepository, mapper);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    // A read may be served by a lagging secondary and miss a promotion another node has just written. Deciding
+    // existence from such a read refused updates the database would have accepted.
+    @Test
+    public void shouldUpdateAPromotionThatReadsCannotSeeYet() throws TechnicalException {
+        Promotion promotion = new Promotion();
+        promotion.setId("promotion#1");
+
+        when(internalRepository.findById("promotion#1")).thenReturn(Optional.empty());
+        when(internalRepository.replace(any())).thenReturn(true);
+
+        Promotion updated = mongoPromotionRepository.update(promotion);
+
+        assertThat(updated).isEqualTo(promotion);
+        verify(internalRepository, never()).save(any());
+    }
+
+    @Test
+    public void shouldRejectTheUpdateWhenNoPromotionCarriesThatId() {
+        Promotion promotion = new Promotion();
+        promotion.setId("unknown");
+
+        when(internalRepository.replace(any())).thenReturn(false);
+
+        assertThatThrownBy(() -> mongoPromotionRepository.update(promotion))
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessageContaining("unknown");
+    }
+
+    @Test
+    public void shouldRejectANullPromotion() {
+        assertThatThrownBy(() -> mongoPromotionRepository.update(null)).isInstanceOf(IllegalStateException.class);
+    }
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/management/PromotionRepositoryTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/management/PromotionRepositoryTest.java
@@ -16,6 +16,7 @@
 package io.gravitee.repository.management;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import io.gravitee.repository.management.api.search.Order;
 import io.gravitee.repository.management.api.search.PromotionCriteria;
@@ -108,6 +109,14 @@ public class PromotionRepositoryTest extends AbstractManagementRepositoryTest {
 
         Promotion dbPromotion = promotionRepository.findById("promotion#1").get();
         assertThat(dbPromotion).isEqualTo(storedPromotion);
+    }
+
+    @Test
+    public void shouldNotUpdateUnknownPromotion() {
+        final Promotion unknownPromotion = new Promotion();
+        unknownPromotion.setId("unknown");
+
+        assertThrows(IllegalStateException.class, () -> promotionRepository.update(unknownPromotion));
     }
 
     @Test

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/promotion/PromotionServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/promotion/PromotionServiceImpl.java
@@ -263,10 +263,10 @@ public class PromotionServiceImpl extends AbstractService implements PromotionSe
      * check can miss a row the other transaction has not committed yet, which surfaced as a raw primary key
      * violation. Treat the conflict as what it means - somebody else got there first - and update instead.
      *
-     * The conflict is recognised from the exception alone. Reading the row back to confirm it exists repeats the
-     * very lookup that already missed it, and a read that is not guaranteed to see the row the other transaction
-     * just committed lets the violation escape again; the update is a write, so it always resolves against the
-     * committed row.
+     * The conflict is recognised from the exception alone: reading the row back to confirm it exists repeats the
+     * very lookup that already missed it. The UPDATE statement resolves against the committed row, but update()
+     * hands back what a read finds afterwards, and that read can miss the row just as the first one did - so
+     * return the promotion that was written instead of the one read back.
      */
     private Promotion createOrUpdateOnConflict(Promotion promotion) throws TechnicalException {
         try {
@@ -276,7 +276,8 @@ public class PromotionServiceImpl extends AbstractService implements PromotionSe
                 throw e;
             }
             log.debug("Promotion {} was created concurrently, updating it instead", promotion.getId());
-            return promotionRepository.update(promotion);
+            promotionRepository.update(promotion);
+            return promotion;
         }
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/promotion/PromotionServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/promotion/PromotionServiceImpl.java
@@ -73,6 +73,7 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 import lombok.CustomLog;
 import org.springframework.context.annotation.Lazy;
+import org.springframework.dao.DuplicateKeyException;
 import org.springframework.stereotype.Component;
 import org.springframework.util.CollectionUtils;
 import org.springframework.util.StringUtils;
@@ -261,17 +262,32 @@ public class PromotionServiceImpl extends AbstractService implements PromotionSe
      * environment that starts it and by the Cockpit bridge that receives it, and when both share a database the
      * check can miss a row the other transaction has not committed yet, which surfaced as a raw primary key
      * violation. Treat the conflict as what it means - somebody else got there first - and update instead.
+     *
+     * The conflict is recognised from the exception alone. Reading the row back to confirm it exists repeats the
+     * very lookup that already missed it, and a read that is not guaranteed to see the row the other transaction
+     * just committed lets the violation escape again; the update is a write, so it always resolves against the
+     * committed row.
      */
     private Promotion createOrUpdateOnConflict(Promotion promotion) throws TechnicalException {
         try {
             return promotionRepository.create(promotion);
         } catch (Exception e) {
-            if (promotionRepository.findById(promotion.getId()).isEmpty()) {
+            if (!isDuplicateKey(e)) {
                 throw e;
             }
             log.debug("Promotion {} was created concurrently, updating it instead", promotion.getId());
             return promotionRepository.update(promotion);
         }
+    }
+
+    /** The JDBC repositories wrap the conflict into a TechnicalException, the Mongo one lets it escape as is. */
+    private static boolean isDuplicateKey(Throwable throwable) {
+        for (Throwable cause = throwable; cause != null; cause = cause.getCause()) {
+            if (cause instanceof DuplicateKeyException) {
+                return true;
+            }
+        }
+        return false;
     }
 
     @Override

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/promotion/PromotionServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/promotion/PromotionServiceTest.java
@@ -286,6 +286,24 @@ public class PromotionServiceTest {
         verify(promotionRepository, times(1)).update(any());
     }
 
+    // JdbcAbstractCrudRepository.update returns findById(...).orElse(null), so the read that missed the row can
+    // miss it again right after the update wrote it. The recovery must not hand that null back to the caller.
+    @Test
+    public void shouldReturnTheWrittenPromotionWhenTheUpdateReadBackMissesIt() throws TechnicalException {
+        when(promotionRepository.findById(any())).thenReturn(Optional.empty());
+        when(promotionRepository.create(any())).thenThrow(
+            new TechnicalException(
+                "Failed to create promotion",
+                new DuplicateKeyException("Violation of PRIMARY KEY constraint 'pk_apim_promotions'")
+            )
+        );
+        when(promotionRepository.update(any())).thenReturn(null);
+
+        final PromotionEntity result = promotionService.createOrUpdate(getAPromotionEntity());
+
+        assertThat(result.getApiId()).isEqualTo("api#1");
+    }
+
     @Test
     public void shouldRethrowWhenTheCreateFailureIsNotAConflict() throws TechnicalException {
         when(promotionRepository.findById(any())).thenReturn(Optional.empty());

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/promotion/PromotionServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/promotion/PromotionServiceTest.java
@@ -79,6 +79,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.dao.DuplicateKeyException;
 
 /**
@@ -265,12 +266,32 @@ public class PromotionServiceTest {
         verify(promotionRepository, times(1)).update(any());
     }
 
+    // The row the conflict proves exists is not always visible to the next read: on SQL Server the lookup that
+    // missed it before the insert missed it again right after the violation, and the promotion failed with the
+    // very duplicate key this recovery exists to absorb.
+    @Test
+    public void shouldUpdateWhenTheConflictingPromotionIsStillInvisibleToReads() throws TechnicalException {
+        when(promotionRepository.findById(any())).thenReturn(Optional.empty());
+        when(promotionRepository.create(any())).thenThrow(
+            new TechnicalException(
+                "Failed to create promotion",
+                new DuplicateKeyException("Violation of PRIMARY KEY constraint 'pk_apim_promotions'")
+            )
+        );
+        when(promotionRepository.update(any())).thenReturn(getAPromotion());
+
+        promotionService.createOrUpdate(getAPromotionEntity());
+
+        verify(promotionRepository, times(1)).create(any());
+        verify(promotionRepository, times(1)).update(any());
+    }
+
     @Test
     public void shouldRethrowWhenTheCreateFailureIsNotAConflict() throws TechnicalException {
         when(promotionRepository.findById(any())).thenReturn(Optional.empty());
-        when(promotionRepository.create(any())).thenThrow(new DuplicateKeyException("boom"));
+        when(promotionRepository.create(any())).thenThrow(new DataIntegrityViolationException("boom"));
 
-        assertThrows(DuplicateKeyException.class, () -> promotionService.createOrUpdate(getAPromotionEntity()));
+        assertThrows(DataIntegrityViolationException.class, () -> promotionService.createOrUpdate(getAPromotionEntity()));
     }
 
     // JdbcAbstractCrudRepository.create wraps every failure into a checked TechnicalException, so on the JDBC


### PR DESCRIPTION
## Issue
https://gravitee.atlassian.net/browse/APIM-15024

## Problem

APIM-14594 made `PromotionServiceImpl.createOrUpdate` tolerate a concurrent insert: on a duplicate key it
confirms the row exists and updates it instead of letting the violation escape.

The confirmation is a read, and it is the *same* lookup that had already missed the row a moment earlier:

```java
} catch (Exception e) {
    if (promotionRepository.findById(promotion.getId()).isEmpty()) {
        throw e;   // <- fires, and the DuplicateKeyException escapes after all
    }
```

`PromotionServiceImpl` is not transactional, so every repository call runs on its own autocommit connection.
When that second read still does not see the row the other transaction committed, the recovery rethrows the
very `DuplicateKeyException` it exists to absorb, and the promotion fails with
`Violation of PRIMARY KEY constraint 'pk_apim_promotions'` — now raised from `createOrUpdateOnConflict`.

Reported against 4.10.28 on SQL Server with Always On Availability Groups: the promotion row is present in
`apim_promotions` with `status=TO_BE_VALIDATED`, yet the read inside the catch block came back empty.

The same mistake — deciding from a read what a write can answer — appears twice more on the path, so all
three are fixed here.

## Fix

**1. The conflict is recognised from the exception, not from a re-read** (`PromotionServiceImpl`).
An exception is proof the id exists; a read is not proof it does not. `apim_promotions` carries no unique
constraint other than its primary key, so a `DuplicateKeyException` on that table can only mean that id is
already taken. The JDBC repositories wrap the conflict into a `TechnicalException` and the Mongo one lets
Spring's `DuplicateKeyException` escape as is, so the check walks the cause chain.

**2. The recovery returns what it wrote, not what it read back.**
`update()` hands back the result of a read performed after writing — `JdbcAbstractCrudRepository:86` returns
`findById(...).orElse(null)`. Under the same invisibility that read can miss the row again, and the caller
received `null` and failed with a `NullPointerException` instead of the promotion.

**3. Mongo decides existence from the replacement instead of a preceding read** (`MongoPromotionRepository`).
`MongoFactory:282-298` supports `readPreference`, so reads may be served by a lagging secondary; the old
`findById`-then-`save` refused updates the database would have accepted, throwing before any write. It now
uses `mongoTemplate.findAndReplace(...)`, which answers from the primary in one atomic operation, following
the precedent in `MongoGammaDashboardRepository:115`. The contract is unchanged — an absent promotion still
raises `IllegalStateException`, as the sibling repositories do and as the shared suite asserts elsewhere.

## Tests

`PromotionServiceTest`

- **added** `shouldUpdateWhenTheConflictingPromotionIsStillInvisibleToReads` — reproduces the report: the
  insert conflicts and the verification read still misses the row.
- **added** `shouldReturnTheWrittenPromotionWhenTheUpdateReadBackMissesIt` — `update()` returns `null`, as
  the JDBC read-back does when it misses. Reverting turns it red with the `NullPointerException` above.
- **changed** `shouldRethrowWhenTheCreateFailureIsNotAConflict` — it threw a `DuplicateKeyException` while
  asserting the "not a conflict" path, which only held because the empty read was doing the discriminating.
  It now throws a `DataIntegrityViolationException`, so it tests what its name says.

`MongoPromotionRepositoryTest` (new) — models the lagging read: `findById` empty, replacement matched,
update succeeds. Restoring the read-then-save form turns it red.

`PromotionRepositoryTest` — gains `shouldNotUpdateUnknownPromotion`, which runs against both backends. It
passes with and without the change: it is a contract guard against a future fix that silently upserts, not
coverage of this bug.

Every behaviour change above was mutation-checked in both directions. The container-backed repository suite
covers the real `findAndReplace`: 15 green on Mongo (both surefire executions) and 15 on JDBC, and mutating
`replace()` to always report a match turns two of them red.

Not verified against a live SQL Server Always On cluster, nor against a lagging Mongo secondary — those
reproductions are deterministic models of the reported failure, not the reported environments.

## Backports

`createOrUpdateOnConflict` carries the identical guard on `4.9.x`, `4.10.x`, `4.11.x` and `4.12.x` (checked
per branch), so all four are labelled. Note `PromotionServiceTest` is JUnit 4 on every support branch, so
the test file will conflict on its imports and on the retargeted test; the 4.10.x variant is already
compiled and green, so the resolution is known rather than a surprise.

## Follow-up, not in this PR

The conflict path calls `update(promotion)` without the `targetApiId` merge the `existingPromotion.isPresent()`
branch performs a few lines above. A conflicting update whose entity has a null `targetApiId` can still drop
the link that branch's comment says must be preserved. Pre-existing, introduced with APIM-14594.
